### PR TITLE
Feature/rtd configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,7 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
 # For version 2 (latest version), this spec is required
 version: 2
 
@@ -6,5 +10,5 @@ sphinx:
   configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF
-formats:
-#  - html
+# No additional formats
+formats: []


### PR DESCRIPTION
## Description

This PR adds a configuration file for ReadTheDocs that disables the latex build step. With this configuration, only the html is built (and published).

I had to place the feature branch in the JDCSA organization so that I could get ReadTheDocs to build directly from the feature branch. This was done so I could verify the configuration was correct without having to merge my attempts into develop.

So I have verified that this skips the latex step and only builds/publishes the html.

## Definition of Done

Done is when ReadTheDocs only builds and publishes the html.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #<issue_number>

## Dependencies

None

## Impact

None
