### PR TITLE
name of tutorial container inconsistent with docs

### DIFF
--- a/docs/using/jedi_environment/containers.rst
+++ b/docs/using/jedi_environment/containers.rst
@@ -58,13 +58,13 @@ Available Containers
 
 The public containers currently offered by jcsda include:
 
-    - :code:`gnu-openmpi-tut`
+    - :code:`tutorial`
     - :code:`gnu-openmpi-dev`
     - :code:`clang-mpich-dev`
 
 Containers that include :code:`-dev` in their name are development containers as described :ref:`above <top-Containers>`.  This means that they contain the JEDI dependencies and compilers but not the JEDI code itself.
 
-The ``gnu-openmpi-tut`` container is designed for use with the :doc:`JEDI Tutorials <../../learning/tutorials/index>`.
+The ``tutorial`` container is designed for use with the :doc:`JEDI Tutorials <../../learning/tutorials/index>`.
 
 If you have it available, we recommend the use of Singularity.  To obtain the Singularity versions of these containers enter
 


### PR DESCRIPTION
## Description

The name of the tutorial container listed here is inconsisten with the documentation

## Definition of Done

What does it mean for this issue to be done?  Is there a specific, measurable, milestone?

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #<issue_number>

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- waiting on JCSDA/eckit/pull/<pr_number>
- waiting on JCSDA/atlas/pull/<pr_number>

## Impact

If changes in this PR will affect other repositories, please add a "waiting for other repos" label, and list the repositories that will be affected to the best of your knowledge (example below).
Requires changes in the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ufo
- [ ] ...

If changes in this PR require updating test data on AWS please add an "update test data" label and list the test data that needs to be updated to the best of your knowledge (example below).
Requires updating AWS test data for the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ...

Note: to automatically run saber, ioda and ufo tests with this PR, push a commit containing "trigger pipeline", e.g.:
git commit --allow-empty -m 'trigger pipeline'
