### PR TITLE
Updated compilation info.

### DIFF
--- a/howto/macos/minimum.md
+++ b/howto/macos/minimum.md
@@ -1,11 +1,16 @@
 ## Minimum steps for working with JEDI natively on Mac OS
 
-Tested on *MacOS 10.15.7 (Catalina).*
+Tested on the following versions of MacOS:
+
+- MacOS 10.15.7 (Catalina)
+- MacOS 10.14.6 (Mojave)
+
 **Note:** Some steps of this process require administrator privileges for the Mac. If you do not have administrator privileges, you will need to work closely with someone who does, both for the initial installation and for ongoing jedi-stack maintenance. You might instead consider [installing vagrant](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/using/jedi_environment/vagrant.html) and then using the [JEDI Singularity containers](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/using/jedi_environment/singularity.html) for JEDI on your Mac, as this will be an easier environment to maintain without administrator privileges.
 
 ### Basic tools
 
 Use homebrew to install the basic required tools:
+
 ```
 boost
 cmake
@@ -23,6 +28,7 @@ Note that some bundles (e.g. `fv3-bundle`) require OpenMP. If you need that, als
 Make sure to add the appropriate `lmod` init script to your shell as described on the [lmod homebrew formula page](https://formulae.brew.sh/formula/lmod).
 
 While editing your shell initialization file for the `lmod` init script, also add the following lines in preparation for the next step:
+
 ```bash
 export JEDI_OPT=/opt/modules
 module use $JEDI_OPT/modulefiles/core
@@ -34,6 +40,12 @@ module use $JEDI_OPT/modulefiles/core
 git clone https://github.com/jcsda-internal/jedi-stack.git
 ```
 
+or
+
+```bash
+git clone https://github.com/JCSDA/jedi-stack.git
+```
+
 (Note that in what follows only gfortran is used from the `brew`-installed `gcc` package.)
 
 Within the cloned jedi-stack repository, edit `buildscripts/config/config_mac.sh`. You need to set the compiler and MPI versions you want to use. In my case I chose:
@@ -43,56 +55,76 @@ export JEDI_COMPILER="clang/12.0.0"
 export JEDI_MPI="mpich/3.3.2"
 ```
 
-Note: this document is written with these compiler/mpi selections assumed, as well as other default settings in `config_mac.sh`. You will need to modify these instructions if you make edits to that file.
+**Note:** if you are runnig a different version of Mac OS X, your `clang` version may differ (eg., for Mac OS Mojave 10.14.6, the clang version is 11.0.0).
+
+**Note:** this document is written with these compiler/mpi selections assumed, as well as other default settings in `config_mac.sh`. You will need to modify these instructions if you make edits to that file.
 
 If any modules are already loaded, clear them with `module purge` before proceeding. Then from the `buildscripts` directory, run:
+
 ```bash
 ./setup_modules.sh mac
 ```
 
-If you have errors with the compiler when running the script, you may need to set the following environment variable. (Probably Catalina-specific)
+If you have errors with the compiler when running the script, you may need to set the following environment variable (probably Catalina-specific and not needed for the referred version of Mojave):
+
 ```bash
 export CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/
 ```
 
 Now you can go to the second step and build the JEDI stack itself. You need to edit `buildscripts/config/choose_modules.sh` to select the components you want. The `choose_modules.sh` file has been organized with a minimal jedi-stack section at the top, so you should set all the variables in that section to `Y`, except for those corresponding to packages that you have already installed using homebrew above or that have been provided by MacOS (LAPACK). So only the following packages from the "Minimal JEDI Stack" section should be set to "N":
+
 - CMAKE
 - GITLFS
 - LAPACK
 - EIGEN3
 
-Note: You will need more modules selected if you want to run certain bundles. Some additional requirements include:
+**Note:** You will need more modules selected if you want to run certain bundles. Some additional requirements include:
+
 - For `mpas-bundle`: PIO
 - For `soca-science`: NCO
 
 Then from the `buildscripts` directory, run:
+
 ```bash
 ./build_stack.sh mac
 ```
 
+Check the newly available modules with the command:
+
+```bash
+module spider
+```
+
 All the selected modules can now be loaded:
+
 ```bash
 module load jedi-clang/12.0.0
 module load jedi-mpich/3.3.2
-module load hdf5 netcdf pnetcdf nccmp ecbuild
+module load atlas hdf5 netcdf pnetcdf nccmp ecbuild eckit fckit gsl_lite
 ```
+
+**Note:** some versions of the modules may differ between the different tested versions of MacOS.
 
 You are now ready for JEDI!
 
 ### Get and build JEDI
 
 You can now choose the bundle you want to work with, the example below is with fv3-bundle:
+
 ```bash
 git clone https://github.com/JCSDA/fv3-bundle.git
 ```
 
 Then build and run ctest:
+
 ```bash
 cd /path/to/build/directory
 ecbuild -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl /path/to/fv3-bundle
 make -j4
 ctest
 ```
+
+**Note:** before running the command above, check the if path is wheter `/usr/local/opt/openssl` or `/usr/local/opt/openssl\@1.1` and set the variable `-DOPENSSL_ROOT_DIR` accordingly.
 
 **Note:** In reality I don't clone a bundle. I have a directory that contains all the repos I'm interested in, and in the same directory a `CMakeLists.txt` (the only file that matters in a bundle repo) that contains all the repos and where I comment or uncomment the repos I want at a given time. This way I have only one copy of each repo, and can work with any application (bundle) I am interested in, including more than one model at the same time. When I want to add a repo I just add it to the `CMakeLists.txt` and ecbuild will get it for me. I include `eckit` in my bundle because it's only built the first time so it's not a big burden and I like to have the code just there when I'm looking for a function I want to use.
 
@@ -101,6 +133,7 @@ the modules "individually" as described above. If this happens to you, try this 
 
 In addition to the `STACK_BUILD` variables listed above, also set the following variables to `Y` in `choose_modules.sh`
 before running `./build_stack.sh mac`:
+
 ```bash
 STACK_BUILD_JSON
 STACK_BUILD_JSON_SCHEMA_VALIDATOR
@@ -120,14 +153,15 @@ module load jedi/clang-mpich
 
 Now clear your `CMakeCache.txt` from your build directory and try to build again.
 
-**Troubleshooting 2** If, when building a bundle, you get an error containing wording like `...your binary is not an allowed client of /usr/lib/libcrypto.dylib`,
+**Troubleshooting 2:** If, when building a bundle, you get an error containing wording like `...your binary is not an allowed client of /usr/lib/libcrypto.dylib`,
 it means that the linker is trying to link to the macOS OpenSSL libraries (which is not allowed) instead of the homebrew-installed openssl libraries.
 One solution to this problem is to add the option `-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl` to your `ecbuild` command for the bundle.
 
-**Troubleshooting 3**
-Some people have encountered errors like this while building the jedi-stack:
+**Troubleshooting 3:** Some people have encountered errors like this while building the jedi-stack:
+
 ```bash
 sudo: 4294967295: invalid value
 sudo: error initializing audit plugin sudoers_audit
 ```
-This appears to be an [intermittent, unresolved MacOS issue](https://discussions-cn-prz.apple.com/en/thread/252518458). Try, try again.
+
+This appears to be an [intermittent, unresolved MacOS issue](https://discussions-cn-prz.apple.com/en/thread/252518458). Try again.


### PR DESCRIPTION
The compilaton was tested against MacOS Mojave (10.14.6) and the necessary information was added to the file.

## Description

The information originally provided in the file is related to MacOS X Catalina. A revision of the file was made by following the instructions in a machine running MacOS X Mojave (10.14.6) and the necessary information to prepare the compilation environment using the referred operational system version was added accordingly. 

## Definition of Done

The revision of the compilation instructions lets the user to properly compile fv3-bundle code against MacOS X Mojave (10.14.6).

### Issue(s) addressed

There is no issues oppened for this PR.

## Dependencies

There is no dependencies.

## Impact

Since the revision does not change the original information regarding MacOS X Catalina, there should be no impact to what is already known.