### PR TITLE
Fix broken link in AWS document

### DIFF
--- a/docs/using/jedi_environment/cloud/singlenode.rst
+++ b/docs/using/jedi_environment/cloud/singlenode.rst
@@ -12,7 +12,7 @@ As described elsewhere in :doc:`this chapter <index>`, there are several steps y
 
 When you have completed these steps, you are ready to launch a single JEDI EC2 instance through the `EC2 Dashboard <https://console.aws.amazon.com/ec2>`_ on the AWS console.
 
-As part of this release, two Amazon Media Images (AMIs) are available that have the necessary `spack-stack-1.3.1` environment for `skylab-4.0.0` pre-installed. For more information on how to find these AMIs, refer to the `spack-stack documentation <https://spack-stack.readthedocs.io/en/1.3.1/Platforms.html>`_.
+As part of this release, two Amazon Media Images (AMIs) are available that have the necessary `spack-stack-1.3.1` environment for `skylab-4.0.0` pre-installed. For more information on how to find these AMIs, refer to the `spack-stack documentation <https://spack-stack.readthedocs.io/en/1.3.1/PreConfiguredSites.html>`_.
 
 .. _singlenode-launch:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinxcontrib-bibtex
 myst_parser
 sphinx_rtd_theme==0.5.2
 docutils==0.16
+urllib3<2


### PR DESCRIPTION
## Description

Fixing a broken link found in the documentation. 

## Definition of Done

Link works and points to correct location. 

## Dependencies

None

## Impact

None
