### PR TITLE
Correct DrawValueFromFile.rst

### DIFF
--- a/docs/inside/jedi-components/ufo/qcfilters/obsfunctions/DrawValueFromFile.rst
+++ b/docs/inside/jedi-components/ufo/qcfilters/obsfunctions/DrawValueFromFile.rst
@@ -31,7 +31,7 @@ is chosen in the examples below).
              file: <path-to-input>    # path to the CSV/NetCDF file
              group: DerivedObsValue   # group with the payload variable
              interpolation:
-             - name: MetaData/satelliteIdentifier
+             - name: MetaData/stationIdentification
                method: exact
 
 and the CSV file, located at :code:`<path-to-input>`, might look like this:
@@ -233,7 +233,7 @@ channels as well as additional variables over which the payload varies.
              interpolation:
              - name: MetaData/satelliteIdentifier
                method: exact
-             - name: MetaData/dataProviderOrigin
+             - name: MetaData/sensorChannelNumber
                method: exact
              - name: MetaData/pressure
                method: linear
@@ -246,7 +246,7 @@ channel information to be described by the name `MetaData/sensorChannelNumber` a
 
 This might be described by a CSV similar to: ::
 
-    MetaData/stationIdentification,MetaData/pressure,MetaData/sensorChannelNumber,DerivedObsValue/mydata
+    MetaData/satelliteIdentifier,MetaData/pressure,MetaData/sensorChannelNumber,DerivedObsValue/mydata
     string,float,int,float
     ABC,30000,0, 0.1
     ABC,60000,0, 0.2


### PR DESCRIPTION
Examples 1 and 2 have some incorrect variable names in the YAML to be consistent with the explanation and the CSV and NetCDF snippets. In example 2, the CSV file also needs updating for consistency with the rest of the documentation.